### PR TITLE
【ボリューム】ボリュームが見つからない場合の対応

### DIFF
--- a/internal/app/api/usecase/volume.go
+++ b/internal/app/api/usecase/volume.go
@@ -71,6 +71,9 @@ func (u *volumeUsecase) Update(ctx context.Context, accountID, id uuid.UUID, nam
 		if err != nil {
 			return err
 		}
+		if volume == nil {
+			return ErrVolumeNotFound
+		}
 
 		if err := volume.SetName(name); err != nil {
 			return err
@@ -94,6 +97,9 @@ func (u *volumeUsecase) Delete(ctx context.Context, accountID, id uuid.UUID) err
 		volume, err := u.volumeRepo.FindOneByIDAndAccountID(ctx, id, accountID)
 		if err != nil {
 			return err
+		}
+		if volume == nil {
+			return ErrVolumeNotFound
 		}
 
 		return u.volumeRepo.Delete(ctx, volume)

--- a/internal/app/api/usecase/volume_test.go
+++ b/internal/app/api/usecase/volume_test.go
@@ -302,6 +302,30 @@ func TestVolume_Update(t *testing.T) {
 			},
 		},
 		{
+			name:           "not found",
+			inputAccountID: accountID,
+			inputID:        id,
+			expectResult:   nil,
+			expectError:    usecase.ErrVolumeNotFound,
+			setMockTransactionObj: func(ctx context.Context, transactionObj *mockTransaction.MockTransactionObject) {
+				transactionObj.
+					EXPECT().
+					Transaction(ctx, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, fn func(context.Context) error) error {
+						return fn(ctx)
+					}).
+					Times(1)
+			},
+			setMockVolumeRepo: func(ctx context.Context, volumeRepo *mockRepository.MockVolumeRepository) {
+				volumeRepo.
+					EXPECT().
+					FindOneByIDAndAccountID(ctx, gomock.Any(), gomock.Any()).
+					Return(nil, nil).
+					Times(1)
+			},
+			setMockVolumeServ: func(context.Context, *mockService.MockVolumeService) {},
+		},
+		{
 			name:           "find error",
 			inputAccountID: accountID,
 			inputID:        id,
@@ -441,6 +465,28 @@ func TestVolume_Delete(t *testing.T) {
 					EXPECT().
 					Delete(ctx, gomock.Any()).
 					Return(nil).
+					Times(1)
+			},
+		},
+		{
+			name:           "not found",
+			inputAccountID: accountID,
+			inputID:        id,
+			expectError:    usecase.ErrVolumeNotFound,
+			setMockTransactionObj: func(ctx context.Context, transactionObj *mockTransaction.MockTransactionObject) {
+				transactionObj.
+					EXPECT().
+					Transaction(ctx, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, fn func(context.Context) error) error {
+						return fn(ctx)
+					}).
+					Times(1)
+			},
+			setMockVolumeRepo: func(ctx context.Context, volumeRepo *mockRepository.MockVolumeRepository) {
+				volumeRepo.
+					EXPECT().
+					FindOneByIDAndAccountID(ctx, gomock.Any(), gomock.Any()).
+					Return(nil, nil).
 					Times(1)
 			},
 		},


### PR DESCRIPTION
# Issue
- close: #69 

# 確認事項
- 更新時にボリュームが見つからない場合404が返却されることを確認
- 削除時にボリュームが見つからない場合に404が返却されることを確認
