### PR TITLE
【エントリー】更新機能を実装

### DIFF
--- a/internal/app/api/domain/repository/body.go
+++ b/internal/app/api/domain/repository/body.go
@@ -5,4 +5,5 @@ import "io"
 
 type BodyRepository interface {
 	Create(string, io.Reader) error
+	Update(string, string) error
 }

--- a/internal/app/api/domain/repository/entry.go
+++ b/internal/app/api/domain/repository/entry.go
@@ -14,4 +14,5 @@ type EntryRepository interface {
 	Update(context.Context, *entity.Entry) error
 	FindOneByKeyAndVolumeID(context.Context, string, uuid.UUID) (*entity.Entry, error)
 	FindOneByIDAndAccountID(context.Context, uuid.UUID, uuid.UUID) (*entity.Entry, error)
+	FindByKeyPrefixAndAccountID(context.Context, string, uuid.UUID) ([]*entity.Entry, error)
 }

--- a/internal/app/api/domain/repository/entry.go
+++ b/internal/app/api/domain/repository/entry.go
@@ -11,5 +11,6 @@ import (
 
 type EntryRepository interface {
 	Create(context.Context, *entity.Entry) error
+	Update(context.Context, *entity.Entry) error
 	FindOneByKeyAndVolumeID(context.Context, string, uuid.UUID) (*entity.Entry, error)
 }

--- a/internal/app/api/domain/repository/entry.go
+++ b/internal/app/api/domain/repository/entry.go
@@ -13,4 +13,5 @@ type EntryRepository interface {
 	Create(context.Context, *entity.Entry) error
 	Update(context.Context, *entity.Entry) error
 	FindOneByKeyAndVolumeID(context.Context, string, uuid.UUID) (*entity.Entry, error)
+	FindOneByIDAndAccountID(context.Context, uuid.UUID, uuid.UUID) (*entity.Entry, error)
 }

--- a/internal/app/api/domain/service/entry.go
+++ b/internal/app/api/domain/service/entry.go
@@ -22,6 +22,7 @@ var (
 type EntryService interface {
 	Exists(context.Context, *entity.Entry) error
 	Create(context.Context, *entity.Volume, *entity.Entry, io.Reader) error
+	Update(context.Context, *entity.Entry, string) error
 }
 
 type entryService struct {
@@ -51,7 +52,7 @@ func (s *entryService) Exists(ctx context.Context, entry *entity.Entry) error {
 	return ErrEntryAlreadyExists
 }
 
-func (s entryService) Create(ctx context.Context, volume *entity.Volume, entry *entity.Entry, body io.Reader) error {
+func (s *entryService) Create(ctx context.Context, volume *entity.Volume, entry *entity.Entry, body io.Reader) error {
 	if volume == nil {
 		return ErrRequiredVolume
 	}
@@ -84,7 +85,11 @@ func (s entryService) Create(ctx context.Context, volume *entity.Volume, entry *
 	return s.bodyRepo.Create(path, body)
 }
 
-func (s entryService) extractDirs(key string) []string {
+func (s *entryService) Update(ctx context.Context, entry *entity.Entry, src string) error {
+	return errors.New("not implemented")
+}
+
+func (s *entryService) extractDirs(key string) []string {
 	dirKey := filepath.Dir(key)
 	if dirKey == "." {
 		return nil

--- a/internal/app/api/domain/service/entry.go
+++ b/internal/app/api/domain/service/entry.go
@@ -22,7 +22,7 @@ var (
 type EntryService interface {
 	Exists(context.Context, *entity.Entry) error
 	Create(context.Context, *entity.Volume, *entity.Entry, io.Reader) error
-	Update(context.Context, *entity.Entry, string) error
+	Update(context.Context, *entity.Volume, *entity.Entry, string) error
 }
 
 type entryService struct {
@@ -85,7 +85,10 @@ func (s *entryService) Create(ctx context.Context, volume *entity.Volume, entry 
 	return s.bodyRepo.Create(path, body)
 }
 
-func (s *entryService) Update(ctx context.Context, entry *entity.Entry, src string) error {
+func (s *entryService) Update(ctx context.Context, volume *entity.Volume, entry *entity.Entry, src string) error {
+	if volume == nil {
+		return ErrRequiredVolume
+	}
 	if entry == nil {
 		return ErrRequiredEntry
 	}
@@ -109,7 +112,7 @@ func (s *entryService) Update(ctx context.Context, entry *entity.Entry, src stri
 		return err
 	}
 
-	return s.bodyRepo.Update(src, entry.Key)
+	return s.bodyRepo.Update(volume.Name+"/"+src, volume.Name+"/"+entry.Key)
 }
 
 func (s *entryService) extractDirs(key string) []string {

--- a/internal/app/api/domain/service/entry_test.go
+++ b/internal/app/api/domain/service/entry_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/spf13/afero"
 	"go.uber.org/mock/gomock"
 
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/entity"
@@ -233,7 +234,7 @@ func TestEntry_Create(t *testing.T) {
 			},
 		},
 		{
-			name:        "find entry Error",
+			name:        "find entry error",
 			inputVolume: volume,
 			inputEntry:  entry,
 			inputBody:   bytes.NewBufferString("test"),
@@ -309,6 +310,151 @@ func TestEntry_Create(t *testing.T) {
 
 			serv := service.NewEntryService(entryRepo, bodyRepo)
 			if err := serv.Create(ctx, tt.inputVolume, tt.inputEntry, tt.inputBody); !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+		})
+	}
+}
+
+func TestEntry_Update(t *testing.T) {
+	accountID := uuid.New()
+	volumeID := uuid.New()
+	entry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: accountID,
+		VolumeID:  volumeID,
+		Key:       "test",
+		Size:      0,
+		Type:      "folder",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	childEntry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: accountID,
+		VolumeID:  volumeID,
+		Key:       "test/sample.txt",
+		Size:      10000,
+		Type:      "text/plain",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name             string
+		inputEntry       *entity.Entry
+		inputSrc         string
+		expectError      error
+		setMockEntryRepo func(context.Context, *mockRepository.MockEntryRepository)
+		setMockBodyRepo  func(context.Context, *mockRepository.MockBodyRepository)
+	}{
+		{
+			name:        "success",
+			inputEntry:  entry,
+			inputSrc:    "update",
+			expectError: nil,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByKeyPrefixAndAccountID(ctx, "update/", entry.AccountID).
+					Return([]*entity.Entry{childEntry}, nil).
+					AnyTimes()
+				entryRepo.
+					EXPECT().
+					Update(ctx, gomock.Any()).
+					Return(nil).
+					AnyTimes()
+			},
+			setMockBodyRepo: func(_ context.Context, bodyRepo *mockRepository.MockBodyRepository) {
+				bodyRepo.
+					EXPECT().
+					Update(gomock.Any(), gomock.Any()).
+					Return(nil).
+					Times(1)
+			},
+		},
+		{
+			name:             "entry is nil",
+			inputEntry:       nil,
+			inputSrc:         "update",
+			expectError:      service.ErrRequiredEntry,
+			setMockEntryRepo: func(context.Context, *mockRepository.MockEntryRepository) {},
+			setMockBodyRepo:  func(context.Context, *mockRepository.MockBodyRepository) {},
+		},
+		{
+			name:        "find entry error",
+			inputEntry:  entry,
+			inputSrc:    "update",
+			expectError: sql.ErrConnDone,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByKeyPrefixAndAccountID(ctx, "update/", entry.AccountID).
+					Return(nil, sql.ErrConnDone).
+					AnyTimes()
+			},
+			setMockBodyRepo: func(context.Context, *mockRepository.MockBodyRepository) {},
+		},
+		{
+			name:        "update entry error",
+			inputEntry:  entry,
+			inputSrc:    "update",
+			expectError: sql.ErrConnDone,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByKeyPrefixAndAccountID(ctx, "update/", entry.AccountID).
+					Return([]*entity.Entry{childEntry}, nil).
+					AnyTimes()
+				entryRepo.
+					EXPECT().
+					Update(ctx, gomock.Any()).
+					Return(sql.ErrConnDone).
+					AnyTimes()
+			},
+			setMockBodyRepo: func(context.Context, *mockRepository.MockBodyRepository) {},
+		},
+		{
+			name:        "update body error",
+			inputEntry:  entry,
+			inputSrc:    "update",
+			expectError: afero.ErrFileClosed,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByKeyPrefixAndAccountID(ctx, "update/", entry.AccountID).
+					Return([]*entity.Entry{childEntry}, nil).
+					AnyTimes()
+				entryRepo.
+					EXPECT().
+					Update(ctx, gomock.Any()).
+					Return(nil).
+					AnyTimes()
+			},
+			setMockBodyRepo: func(_ context.Context, bodyRepo *mockRepository.MockBodyRepository) {
+				bodyRepo.
+					EXPECT().
+					Update(gomock.Any(), gomock.Any()).
+					Return(afero.ErrFileClosed).
+					Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := t.Context()
+
+			entryRepo := mockRepository.NewMockEntryRepository(ctrl)
+			tt.setMockEntryRepo(ctx, entryRepo)
+
+			bodyRepo := mockRepository.NewMockBodyRepository(ctrl)
+			tt.setMockBodyRepo(ctx, bodyRepo)
+
+			serv := service.NewEntryService(entryRepo, bodyRepo)
+			if err := serv.Update(ctx, tt.inputEntry, tt.inputSrc); !errors.Is(err, tt.expectError) {
 				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
 			}
 		})

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -41,7 +41,14 @@ func (r *entryRepository) Create(ctx context.Context, entry *entity.Entry) error
 }
 
 func (r *entryRepository) Update(ctx context.Context, entry *entity.Entry) error {
-	return errors.New("not implemented")
+	if entry == nil {
+		return ErrRequiredEntry
+	}
+
+	driver := transaction.GetDriver(ctx, r.db)
+	model := transformer.ToEntryModel(entry)
+	_, err := driver.NamedExecContext(ctx, "UPDATE entries SET account_id = :account_id, volume_id = :volume_id, key = :key, size = :size, type = :type, updated_at = :updated_at WHERE id = :id LIMIT 1;", model)
+	return err
 }
 
 func (r *entryRepository) FindOneByKeyAndVolumeID(ctx context.Context, key string, volumeID uuid.UUID) (*entity.Entry, error) {

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -64,5 +64,13 @@ func (r *entryRepository) FindOneByKeyAndVolumeID(ctx context.Context, key strin
 }
 
 func (r *entryRepository) FindOneByIDAndAccountID(ctx context.Context, id, accountID uuid.UUID) (*entity.Entry, error) {
-	return nil, errors.New("not implemented")
+	driver := transaction.GetDriver(ctx, r.db)
+	var model model.EntryModel
+	if err := driver.QueryRowxContext(ctx, "SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE id = ? AND account_id = ? LIMIT 1;", id, accountID).StructScan(&model); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return transformer.ToEntryEntity(&model), nil
 }

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -47,7 +47,7 @@ func (r *entryRepository) Update(ctx context.Context, entry *entity.Entry) error
 
 	driver := transaction.GetDriver(ctx, r.db)
 	model := transformer.ToEntryModel(entry)
-	_, err := driver.NamedExecContext(ctx, "UPDATE entries SET account_id = :account_id, volume_id = :volume_id, key = :key, size = :size, type = :type, updated_at = :updated_at WHERE id = :id LIMIT 1;", model)
+	_, err := driver.NamedExecContext(ctx, "UPDATE entries SET account_id = :account_id, volume_id = :volume_id, `key` = :key, size = :size, type = :type, updated_at = :updated_at WHERE id = :id LIMIT 1;", model)
 	return err
 }
 

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -74,3 +74,7 @@ func (r *entryRepository) FindOneByIDAndAccountID(ctx context.Context, id, accou
 	}
 	return transformer.ToEntryEntity(&model), nil
 }
+
+func (r *entryRepository) FindByKeyPrefixAndAccountID(ctx context.Context, keyword string, accountID uuid.UUID) ([]*entity.Entry, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -62,3 +62,7 @@ func (r *entryRepository) FindOneByKeyAndVolumeID(ctx context.Context, key strin
 	}
 	return transformer.ToEntryEntity(&model), nil
 }
+
+func (r *entryRepository) FindOneByIDAndAccountID(ctx context.Context, id, accountID uuid.UUID) (*entity.Entry, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -40,6 +40,10 @@ func (r *entryRepository) Create(ctx context.Context, entry *entity.Entry) error
 	return err
 }
 
+func (r *entryRepository) Update(ctx context.Context, entry *entity.Entry) error {
+	return errors.New("not implemented")
+}
+
 func (r *entryRepository) FindOneByKeyAndVolumeID(ctx context.Context, key string, volumeID uuid.UUID) (*entity.Entry, error) {
 	driver := transaction.GetDriver(ctx, r.db)
 	var model model.EntryModel

--- a/internal/app/api/infrastructure/database/entry.go
+++ b/internal/app/api/infrastructure/database/entry.go
@@ -75,6 +75,25 @@ func (r *entryRepository) FindOneByIDAndAccountID(ctx context.Context, id, accou
 	return transformer.ToEntryEntity(&model), nil
 }
 
-func (r *entryRepository) FindByKeyPrefixAndAccountID(ctx context.Context, keyword string, accountID uuid.UUID) ([]*entity.Entry, error) {
-	return nil, errors.New("not implemented")
+func (r *entryRepository) FindByKeyPrefixAndAccountID(ctx context.Context, keyword string, accountID uuid.UUID) (entries []*entity.Entry, err error) {
+	driver := transaction.GetDriver(ctx, r.db)
+
+	rows, err := driver.QueryxContext(ctx, "SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE `key` LIKE ? AND account_id = ?;", keyword+"%", accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = rows.Close()
+	}()
+
+	var models []*model.EntryModel
+	for rows.Next() {
+		var model model.EntryModel
+		if err := rows.StructScan(&model); err != nil {
+			return nil, err
+		}
+		models = append(models, &model)
+	}
+
+	return transformer.ToEntryEntities(models), nil
 }

--- a/internal/app/api/infrastructure/database/entry_test.go
+++ b/internal/app/api/infrastructure/database/entry_test.go
@@ -315,3 +315,86 @@ func TestEntry_FindOneByIDAndAccountID(t *testing.T) {
 		})
 	}
 }
+
+func TestEntry_FindByKeyPrefixAndAccountID(t *testing.T) {
+	entry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: uuid.New(),
+		VolumeID:  uuid.New(),
+		Key:       "test/sample.jpg",
+		Size:      10000,
+		Type:      "image/jpeg",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name           string
+		inputKeyword   string
+		inputAccountID uuid.UUID
+		expectResult   []*entity.Entry
+		expectError    error
+		setMockDB      func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:           "success",
+			inputKeyword:   "test/",
+			inputAccountID: entry.AccountID,
+			expectResult:   []*entity.Entry{entry},
+			expectError:    nil,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE `key` LIKE ? AND account_id = ?;")).
+					WithArgs("test/%", entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"}).AddRow(entry.ID, entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.CreatedAt, entry.UpdatedAt)).
+					WillReturnError(nil)
+			},
+		},
+		{
+			name:           "not found",
+			inputKeyword:   "test/",
+			inputAccountID: entry.AccountID,
+			expectResult:   []*entity.Entry{},
+			expectError:    nil,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE `key` LIKE ? AND account_id = ?;")).
+					WithArgs("test/%", entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"})).
+					WillReturnError(nil)
+			},
+		},
+		{
+			name:           "find error",
+			inputKeyword:   "test/",
+			inputAccountID: entry.AccountID,
+			expectResult:   nil,
+			expectError:    sql.ErrConnDone,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE `key` LIKE ? AND account_id = ?;")).
+					WithArgs("test/%", entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"})).
+					WillReturnError(sql.ErrConnDone)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := mockDatabase.NewMockDatabase(t)
+
+			tt.setMockDB(mock)
+
+			repo := database.NewEntryRepository(db)
+			result, err := repo.FindByKeyPrefixAndAccountID(t.Context(), tt.inputKeyword, tt.inputAccountID)
+			if !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+
+			if diff := cmp.Diff(result, tt.expectResult); diff != "" {
+				t.Error(diff)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/internal/app/api/infrastructure/database/entry_test.go
+++ b/internal/app/api/infrastructure/database/entry_test.go
@@ -232,3 +232,86 @@ func TestEntry_FindOneByKeyAndVolumeID(t *testing.T) {
 		})
 	}
 }
+
+func TestEntry_FindOneByIDAndAccountID(t *testing.T) {
+	entry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: uuid.New(),
+		VolumeID:  uuid.New(),
+		Key:       "test/sample.jpg",
+		Size:      10000,
+		Type:      "image/jpeg",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name           string
+		inputID        uuid.UUID
+		inputAccountID uuid.UUID
+		expectResult   *entity.Entry
+		expectError    error
+		setMockDB      func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:           "success",
+			inputID:        entry.ID,
+			inputAccountID: entry.AccountID,
+			expectResult:   entry,
+			expectError:    nil,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE id = ? AND account_id = ? LIMIT 1;")).
+					WithArgs(entry.ID, entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"}).AddRow(entry.ID, entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.CreatedAt, entry.UpdatedAt)).
+					WillReturnError(nil)
+			},
+		},
+		{
+			name:           "not found",
+			inputID:        entry.ID,
+			inputAccountID: entry.AccountID,
+			expectResult:   nil,
+			expectError:    nil,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE id = ? AND account_id = ? LIMIT 1;")).
+					WithArgs(entry.ID, entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"})).
+					WillReturnError(nil)
+			},
+		},
+		{
+			name:           "find error",
+			inputID:        entry.ID,
+			inputAccountID: entry.AccountID,
+			expectResult:   nil,
+			expectError:    sql.ErrConnDone,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, account_id, volume_id, `key`, size, type, created_at, updated_at FROM entries WHERE id = ? AND account_id = ? LIMIT 1;")).
+					WithArgs(entry.ID, entry.AccountID).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "volume_id", "key", "size", "type", "created_at", "updated_at"})).
+					WillReturnError(sql.ErrConnDone)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := mockDatabase.NewMockDatabase(t)
+
+			tt.setMockDB(mock)
+
+			repo := database.NewEntryRepository(db)
+			result, err := repo.FindOneByIDAndAccountID(t.Context(), tt.inputID, tt.inputAccountID)
+			if !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+
+			if diff := cmp.Diff(result, tt.expectResult); diff != "" {
+				t.Error(diff)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/internal/app/api/infrastructure/database/entry_test.go
+++ b/internal/app/api/infrastructure/database/entry_test.go
@@ -82,6 +82,72 @@ func TestEntry_Create(t *testing.T) {
 	}
 }
 
+func TestEntry_Update(t *testing.T) {
+	entry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: uuid.New(),
+		VolumeID:  uuid.New(),
+		Key:       "test/sample.jpg",
+		Size:      10000,
+		Type:      "image/jpeg",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name        string
+		inputEntry  *entity.Entry
+		expectError error
+		setMockDB   func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:        "success",
+			inputEntry:  entry,
+			expectError: nil,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, key = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
+					WithArgs(entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.UpdatedAt, entry.ID).
+					WillReturnResult(sqlmock.NewResult(1, 1)).
+					WillReturnError(nil)
+			},
+		},
+		{
+			name:        "entry is nil",
+			inputEntry:  nil,
+			expectError: database.ErrRequiredEntry,
+			setMockDB:   func(sqlmock.Sqlmock) {},
+		},
+		{
+			name:        "update error",
+			inputEntry:  entry,
+			expectError: sql.ErrConnDone,
+			setMockDB: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, key = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
+					WithArgs(entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.UpdatedAt, entry.ID).
+					WillReturnResult(sqlmock.NewResult(1, 1)).
+					WillReturnError(sql.ErrConnDone)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := mockDatabase.NewMockDatabase(t)
+			defer db.Close()
+
+			tt.setMockDB(mock)
+
+			repo := database.NewEntryRepository(db)
+			if err := repo.Update(t.Context(), tt.inputEntry); !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestEntry_FindOneByKeyAndVolumeID(t *testing.T) {
 	accountID := uuid.New()
 	volumeID := uuid.New()

--- a/internal/app/api/infrastructure/database/entry_test.go
+++ b/internal/app/api/infrastructure/database/entry_test.go
@@ -105,7 +105,7 @@ func TestEntry_Update(t *testing.T) {
 			inputEntry:  entry,
 			expectError: nil,
 			setMockDB: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, key = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, `key` = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
 					WithArgs(entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.UpdatedAt, entry.ID).
 					WillReturnResult(sqlmock.NewResult(1, 1)).
 					WillReturnError(nil)
@@ -122,7 +122,7 @@ func TestEntry_Update(t *testing.T) {
 			inputEntry:  entry,
 			expectError: sql.ErrConnDone,
 			setMockDB: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, key = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE entries SET account_id = ?, volume_id = ?, `key` = ?, size = ?, type = ?, updated_at = ? WHERE id = ? LIMIT 1;")).
 					WithArgs(entry.AccountID, entry.VolumeID, entry.Key, entry.Size, entry.Type, entry.UpdatedAt, entry.ID).
 					WillReturnResult(sqlmock.NewResult(1, 1)).
 					WillReturnError(sql.ErrConnDone)

--- a/internal/app/api/infrastructure/database/transformer/entry.go
+++ b/internal/app/api/infrastructure/database/transformer/entry.go
@@ -30,3 +30,11 @@ func ToEntryEntity(entry *model.EntryModel) *entity.Entry {
 		entry.UpdatedAt,
 	)
 }
+
+func ToEntryEntities(entries []*model.EntryModel) []*entity.Entry {
+	entities := make([]*entity.Entry, len(entries))
+	for i, entry := range entries {
+		entities[i] = ToEntryEntity(entry)
+	}
+	return entities
+}

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -15,13 +15,13 @@ type bodyRepository struct {
 }
 
 func NewBodyRepository(fs afero.Fs, basePath string) repository.BodyRepository {
-	return bodyRepository{
+	return &bodyRepository{
 		fs:       fs,
 		basePath: basePath,
 	}
 }
 
-func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
+func (r *bodyRepository) Create(path string, reader io.Reader) (err error) {
 	if err := r.fs.MkdirAll(r.basePath+filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
 	}
 }
 
-func (r bodyRepository) Update(src string, dst string) error {
+func (r *bodyRepository) Update(src, dst string) error {
 	if err := r.fs.MkdirAll(r.basePath+filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -45,5 +45,5 @@ func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
 }
 
 func (r bodyRepository) Update(src string, dst string) error {
-	return r.fs.Rename(src, dst)
+	return r.fs.Rename(r.basePath+src, r.basePath+dst)
 }

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -45,5 +45,9 @@ func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
 }
 
 func (r bodyRepository) Update(src string, dst string) error {
+	if err := r.fs.MkdirAll(r.basePath+filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
 	return r.fs.Rename(r.basePath+src, r.basePath+dst)
 }

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"errors"
 	"io"
 	"path/filepath"
 
@@ -45,6 +44,6 @@ func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
 	}
 }
 
-func (r bodyRepository) Update(string, string) error {
-	return errors.New("not implemented")
+func (r bodyRepository) Update(src string, dst string) error {
+	return r.fs.Rename(src, dst)
 }

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"io"
 	"path/filepath"
 
@@ -42,4 +43,8 @@ func (r bodyRepository) Create(path string, reader io.Reader) (err error) {
 		_, err = io.Copy(file, reader)
 		return err
 	}
+}
+
+func (r bodyRepository) Update(string, string) error {
+	return errors.New("not implemented")
 }

--- a/internal/app/api/infrastructure/file/body_test.go
+++ b/internal/app/api/infrastructure/file/body_test.go
@@ -43,8 +43,51 @@ func TestBody_Create(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-
 			if exists != tt.expectResult {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectResult, exists)
+			}
+		})
+	}
+}
+
+func TestBody_Update(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputSrc     string
+		inputDst     string
+		expectResult bool
+		expectError  error
+	}{
+		{name: "success", inputSrc: "sample/test.txt", inputDst: "update/test.txt", expectResult: true, expectError: nil},
+		{name: "update error", inputSrc: "sample/test.txt", inputDst: "update/test.txt", expectResult: false, expectError: io.ErrNoProgress},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			basePath := ""
+
+			if err := afero.WriteFile(fs, tt.inputSrc, []byte("test"), 0o755); err != nil {
+				t.Error(err)
+			}
+
+			repo := file.NewBodyRepository(fs, basePath)
+			if err := repo.Update(tt.inputSrc, tt.inputDst); !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+
+			exists, err := afero.Exists(fs, basePath+tt.inputDst)
+			if err != nil {
+				t.Error(err)
+			}
+			if exists != tt.expectResult {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectResult, exists)
+			}
+
+			exists, err = afero.Exists(fs, basePath+tt.inputSrc)
+			if err != nil {
+				t.Error(err)
+			}
+			if exists != !tt.expectResult {
 				t.Errorf("\nexpect: %v\ngot: %v", tt.expectResult, exists)
 			}
 		})

--- a/internal/app/api/interface/handler/entry.go
+++ b/internal/app/api/interface/handler/entry.go
@@ -19,6 +19,7 @@ import (
 
 type EntryHandler interface {
 	Create(*gin.Context)
+	Update(*gin.Context)
 }
 
 type entryHandler struct {
@@ -72,6 +73,8 @@ func (h *entryHandler) Create(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, builder.ToEntryResponse(entry))
 }
+
+func (h *entryHandler) Update(c *gin.Context) {}
 
 func (h *entryHandler) openFile(fileHeader *multipart.FileHeader) (uint64, multipart.File, error) {
 	if fileHeader == nil {

--- a/internal/app/api/interface/handler/entry_test.go
+++ b/internal/app/api/interface/handler/entry_test.go
@@ -166,3 +166,129 @@ func TestEntry_Create(t *testing.T) {
 		})
 	}
 }
+
+func TestEntry_Update(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	id := uuid.New()
+	accountID := uuid.New()
+	volumeID := uuid.New()
+	entryDTO := &dto.EntryDTO{
+		ID:        id,
+		AccountID: accountID,
+		VolumeID:  volumeID,
+		Key:       "test/sample.txt",
+		Size:      4,
+		Type:      "text/plain; charset=utf-8",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name           string
+		requestJSON    []byte
+		isSetID        bool
+		isSetAccountID bool
+		expectCode     int
+		expectResponse map[string]any
+		setMockEntryUC func(context.Context, *mockUsecase.MockEntryUsecase)
+	}{
+		{
+			name:           "success",
+			requestJSON:    []byte(`{"key": "update/sample.txt"}`),
+			isSetID:        true,
+			isSetAccountID: true,
+			expectCode:     http.StatusOK,
+			expectResponse: map[string]any{"id": entryDTO.ID.String(), "volume_id": entryDTO.VolumeID.String(), "key": "update/sample.txt", "size": entryDTO.Size, "type": entryDTO.Type, "created_at": entryDTO.CreatedAt.Format(time.RFC3339Nano), "updated_at": entryDTO.UpdatedAt.Format(time.RFC3339Nano)},
+			setMockEntryUC: func(ctx context.Context, entryUC *mockUsecase.MockEntryUsecase) {
+				entryUC.
+					EXPECT().
+					Update(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(entryDTO, nil).
+					Times(1)
+			},
+		},
+		{
+			name:           "invalid request",
+			requestJSON:    nil,
+			isSetID:        true,
+			isSetAccountID: true,
+			expectCode:     http.StatusBadRequest,
+			expectResponse: map[string]any{"message": "failed to parse json"},
+			setMockEntryUC: func(context.Context, *mockUsecase.MockEntryUsecase) {},
+		},
+		{
+			name:           "id not found",
+			requestJSON:    []byte(`{"key": "update/sample.txt"}`),
+			isSetID:        false,
+			isSetAccountID: true,
+			expectCode:     http.StatusBadRequest,
+			expectResponse: map[string]any{"message": "invalid id"},
+			setMockEntryUC: func(context.Context, *mockUsecase.MockEntryUsecase) {},
+		},
+		{
+			name:           "account id not found",
+			requestJSON:    []byte(`{"key": "update/sample.txt"}`),
+			isSetID:        true,
+			isSetAccountID: false,
+			expectCode:     http.StatusInternalServerError,
+			expectResponse: map[string]any{"message": "internal server error"},
+			setMockEntryUC: func(context.Context, *mockUsecase.MockEntryUsecase) {},
+		},
+		{
+			name:           "update error",
+			requestJSON:    []byte(`{"key": "update/sample.txt"}`),
+			isSetID:        true,
+			isSetAccountID: true,
+			expectCode:     http.StatusInternalServerError,
+			expectResponse: map[string]any{"message": "internal server error"},
+			setMockEntryUC: func(ctx context.Context, entryUC *mockUsecase.MockEntryUsecase) {
+				entryUC.
+					EXPECT().
+					Update(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, sql.ErrConnDone).
+					Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		ctx := t.Context()
+		w := httptest.NewRecorder()
+
+		c, _ := gin.CreateTestContext(w)
+		var err error
+		c.Request, err = http.NewRequestWithContext(ctx, "PUT", "/entries/"+id.String(), bytes.NewBuffer(tt.requestJSON))
+		if err != nil {
+			t.Error(err)
+		}
+		if tt.isSetID {
+			c.Params = append(c.Params, gin.Param{Key: "id", Value: id.String()})
+		}
+		if tt.isSetAccountID {
+			c.Set("accountID", accountID)
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		entryUC := mockUsecase.NewMockEntryUsecase(ctrl)
+		tt.setMockEntryUC(ctx, entryUC)
+
+		hdl := handler.NewEntryHandler(entryUC)
+		hdl.Update(c)
+
+		c.Writer.WriteHeaderNow()
+
+		if w.Code != tt.expectCode {
+			t.Errorf("\nexpect: %v\ngot: %v", tt.expectCode, w.Code)
+		}
+
+		var response map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Error(err)
+		}
+		if diff := cmp.Diff(response, tt.expectResponse); diff != "" {
+			t.Error(diff)
+		}
+	}
+}

--- a/internal/app/api/interface/handler/entry_test.go
+++ b/internal/app/api/interface/handler/entry_test.go
@@ -252,50 +252,52 @@ func TestEntry_Update(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ctx := t.Context()
-		w := httptest.NewRecorder()
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			w := httptest.NewRecorder()
 
-		c, _ := gin.CreateTestContext(w)
-		var err error
-		c.Request, err = http.NewRequestWithContext(ctx, "PUT", "/entries/"+id.String(), bytes.NewBuffer(tt.requestJSON))
-		if err != nil {
-			t.Error(err)
-		}
-		if tt.isSetID {
-			c.Params = append(c.Params, gin.Param{Key: "id", Value: id.String()})
-		}
-		if tt.isSetAccountID {
-			c.Set("accountID", accountID)
-		}
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		entryUC := mockUsecase.NewMockEntryUsecase(ctrl)
-		tt.setMockEntryUC(ctx, entryUC)
-
-		hdl := handler.NewEntryHandler(entryUC)
-		hdl.Update(c)
-
-		c.Writer.WriteHeaderNow()
-
-		if w.Code != tt.expectCode {
-			t.Errorf("\nexpect: %v\ngot: %v", tt.expectCode, w.Code)
-		}
-
-		var response map[string]any
-		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-			t.Error(err)
-		}
-
-		if tt.expectCode == http.StatusOK {
-			if size, ok := response["size"].(float64); ok {
-				response["size"] = uint64(size)
+			c, _ := gin.CreateTestContext(w)
+			var err error
+			c.Request, err = http.NewRequestWithContext(ctx, "PUT", "/entries/"+id.String(), bytes.NewBuffer(tt.requestJSON))
+			if err != nil {
+				t.Error(err)
 			}
-		}
+			if tt.isSetID {
+				c.Params = append(c.Params, gin.Param{Key: "id", Value: id.String()})
+			}
+			if tt.isSetAccountID {
+				c.Set("accountID", accountID)
+			}
 
-		if diff := cmp.Diff(response, tt.expectResponse); diff != "" {
-			t.Error(diff)
-		}
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			entryUC := mockUsecase.NewMockEntryUsecase(ctrl)
+			tt.setMockEntryUC(ctx, entryUC)
+
+			hdl := handler.NewEntryHandler(entryUC)
+			hdl.Update(c)
+
+			c.Writer.WriteHeaderNow()
+
+			if w.Code != tt.expectCode {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectCode, w.Code)
+			}
+
+			var response map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Error(err)
+			}
+
+			if tt.expectCode == http.StatusOK {
+				if size, ok := response["size"].(float64); ok {
+					response["size"] = uint64(size)
+				}
+			}
+
+			if diff := cmp.Diff(response, tt.expectResponse); diff != "" {
+				t.Error(diff)
+			}
+		})
 	}
 }

--- a/internal/app/api/interface/handler/entry_test.go
+++ b/internal/app/api/interface/handler/entry_test.go
@@ -199,7 +199,7 @@ func TestEntry_Update(t *testing.T) {
 			isSetID:        true,
 			isSetAccountID: true,
 			expectCode:     http.StatusOK,
-			expectResponse: map[string]any{"id": entryDTO.ID.String(), "volume_id": entryDTO.VolumeID.String(), "key": "update/sample.txt", "size": entryDTO.Size, "type": entryDTO.Type, "created_at": entryDTO.CreatedAt.Format(time.RFC3339Nano), "updated_at": entryDTO.UpdatedAt.Format(time.RFC3339Nano)},
+			expectResponse: map[string]any{"id": entryDTO.ID.String(), "volume_id": entryDTO.VolumeID.String(), "key": entryDTO.Key, "size": entryDTO.Size, "type": entryDTO.Type, "created_at": entryDTO.CreatedAt.Format(time.RFC3339Nano), "updated_at": entryDTO.UpdatedAt.Format(time.RFC3339Nano)},
 			setMockEntryUC: func(ctx context.Context, entryUC *mockUsecase.MockEntryUsecase) {
 				entryUC.
 					EXPECT().
@@ -287,6 +287,13 @@ func TestEntry_Update(t *testing.T) {
 		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 			t.Error(err)
 		}
+
+		if tt.expectCode == http.StatusOK {
+			if size, ok := response["size"].(float64); ok {
+				response["size"] = uint64(size)
+			}
+		}
+
 		if diff := cmp.Diff(response, tt.expectResponse); diff != "" {
 			t.Error(diff)
 		}

--- a/internal/app/api/interface/schema/entry.go
+++ b/internal/app/api/interface/schema/entry.go
@@ -11,6 +11,10 @@ type CreateEntryRequest struct {
 	Key      string `form:"key" binding:"required"`
 }
 
+type UpdateEntryRequest struct {
+	Key string `json:"key"`
+}
+
 type EntryResponse struct {
 	ID        uuid.UUID `json:"id"`
 	VolumeID  uuid.UUID `json:"volume_id"`

--- a/internal/app/api/router.go
+++ b/internal/app/api/router.go
@@ -17,4 +17,5 @@ func registerRouter(r *gin.Engine) {
 
 	entries := r.Group("entries")
 	entries.POST("/", entryHdl.Create)
+	entries.PUT("/:id", entryHdl.Update)
 }

--- a/internal/app/api/usecase/entry.go
+++ b/internal/app/api/usecase/entry.go
@@ -4,6 +4,7 @@ package usecase
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 
@@ -19,6 +20,7 @@ import (
 
 type EntryUsecase interface {
 	Create(context.Context, uuid.UUID, uuid.UUID, string, uint64, io.Reader) (*dto.EntryDTO, error)
+	Update(context.Context, uuid.UUID, uuid.UUID, string) (*dto.EntryDTO, error)
 }
 
 type entryUsecase struct {
@@ -81,4 +83,8 @@ func (u *entryUsecase) Create(ctx context.Context, accountID, volumeID uuid.UUID
 	}
 
 	return mapper.ToEntryDTO(entry), nil
+}
+
+func (u *entryUsecase) Update(ctx context.Context, accountID, id uuid.UUID, key string) (*dto.EntryDTO, error) {
+	return nil, errors.New("not implemented")
 }

--- a/internal/app/api/usecase/entry.go
+++ b/internal/app/api/usecase/entry.go
@@ -14,9 +14,13 @@ import (
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/repository"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/repository/pkg/transaction"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/service"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status/code"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/usecase/dto"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/usecase/mapper"
 )
+
+var ErrEntryNotFound = status.Error(code.NotFound, "entry not found")
 
 type EntryUsecase interface {
 	Create(context.Context, uuid.UUID, uuid.UUID, string, uint64, io.Reader) (*dto.EntryDTO, error)

--- a/internal/app/api/usecase/entry.go
+++ b/internal/app/api/usecase/entry.go
@@ -101,6 +101,14 @@ func (u *entryUsecase) Update(ctx context.Context, accountID, id uuid.UUID, key 
 			return ErrEntryNotFound
 		}
 
+		volume, err := u.volumeRepo.FindOneByIDAndAccountID(ctx, entry.VolumeID, accountID)
+		if err != nil {
+			return err
+		}
+		if volume == nil {
+			return ErrVolumeNotFound
+		}
+
 		src := entry.Key
 
 		if err := entry.SetKey(key); err != nil {
@@ -111,7 +119,7 @@ func (u *entryUsecase) Update(ctx context.Context, accountID, id uuid.UUID, key 
 			return err
 		}
 
-		return u.entryServ.Update(ctx, entry, src)
+		return u.entryServ.Update(ctx, volume, entry, src)
 	}); err != nil {
 		return nil, err
 	}

--- a/test/mock/domain/repository/body.go
+++ b/test/mock/domain/repository/body.go
@@ -53,3 +53,17 @@ func (mr *MockBodyRepositoryMockRecorder) Create(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockBodyRepository)(nil).Create), arg0, arg1)
 }
+
+// Update mocks base method.
+func (m *MockBodyRepository) Update(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockBodyRepositoryMockRecorder) Update(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockBodyRepository)(nil).Update), arg0, arg1)
+}

--- a/test/mock/domain/repository/entry.go
+++ b/test/mock/domain/repository/entry.go
@@ -56,6 +56,21 @@ func (mr *MockEntryRepositoryMockRecorder) Create(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEntryRepository)(nil).Create), arg0, arg1)
 }
 
+// FindOneByIDAndAccountID mocks base method.
+func (m *MockEntryRepository) FindOneByIDAndAccountID(arg0 context.Context, arg1, arg2 uuid.UUID) (*entity.Entry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOneByIDAndAccountID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*entity.Entry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOneByIDAndAccountID indicates an expected call of FindOneByIDAndAccountID.
+func (mr *MockEntryRepositoryMockRecorder) FindOneByIDAndAccountID(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByIDAndAccountID", reflect.TypeOf((*MockEntryRepository)(nil).FindOneByIDAndAccountID), arg0, arg1, arg2)
+}
+
 // FindOneByKeyAndVolumeID mocks base method.
 func (m *MockEntryRepository) FindOneByKeyAndVolumeID(arg0 context.Context, arg1 string, arg2 uuid.UUID) (*entity.Entry, error) {
 	m.ctrl.T.Helper()

--- a/test/mock/domain/repository/entry.go
+++ b/test/mock/domain/repository/entry.go
@@ -56,6 +56,21 @@ func (mr *MockEntryRepositoryMockRecorder) Create(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEntryRepository)(nil).Create), arg0, arg1)
 }
 
+// FindByKeyPrefixAndAccountID mocks base method.
+func (m *MockEntryRepository) FindByKeyPrefixAndAccountID(arg0 context.Context, arg1 string, arg2 uuid.UUID) ([]*entity.Entry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByKeyPrefixAndAccountID", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*entity.Entry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByKeyPrefixAndAccountID indicates an expected call of FindByKeyPrefixAndAccountID.
+func (mr *MockEntryRepositoryMockRecorder) FindByKeyPrefixAndAccountID(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByKeyPrefixAndAccountID", reflect.TypeOf((*MockEntryRepository)(nil).FindByKeyPrefixAndAccountID), arg0, arg1, arg2)
+}
+
 // FindOneByIDAndAccountID mocks base method.
 func (m *MockEntryRepository) FindOneByIDAndAccountID(arg0 context.Context, arg1, arg2 uuid.UUID) (*entity.Entry, error) {
 	m.ctrl.T.Helper()

--- a/test/mock/domain/repository/entry.go
+++ b/test/mock/domain/repository/entry.go
@@ -70,3 +70,17 @@ func (mr *MockEntryRepositoryMockRecorder) FindOneByKeyAndVolumeID(arg0, arg1, a
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByKeyAndVolumeID", reflect.TypeOf((*MockEntryRepository)(nil).FindOneByKeyAndVolumeID), arg0, arg1, arg2)
 }
+
+// Update mocks base method.
+func (m *MockEntryRepository) Update(arg0 context.Context, arg1 *entity.Entry) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockEntryRepositoryMockRecorder) Update(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEntryRepository)(nil).Update), arg0, arg1)
+}

--- a/test/mock/domain/service/entry.go
+++ b/test/mock/domain/service/entry.go
@@ -71,15 +71,15 @@ func (mr *MockEntryServiceMockRecorder) Exists(arg0, arg1 any) *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockEntryService) Update(arg0 context.Context, arg1 *entity.Entry, arg2 string) error {
+func (m *MockEntryService) Update(arg0 context.Context, arg1 *entity.Volume, arg2 *entity.Entry, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockEntryServiceMockRecorder) Update(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockEntryServiceMockRecorder) Update(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEntryService)(nil).Update), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEntryService)(nil).Update), arg0, arg1, arg2, arg3)
 }

--- a/test/mock/domain/service/entry.go
+++ b/test/mock/domain/service/entry.go
@@ -69,3 +69,17 @@ func (mr *MockEntryServiceMockRecorder) Exists(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockEntryService)(nil).Exists), arg0, arg1)
 }
+
+// Update mocks base method.
+func (m *MockEntryService) Update(arg0 context.Context, arg1 *entity.Entry, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockEntryServiceMockRecorder) Update(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEntryService)(nil).Update), arg0, arg1, arg2)
+}

--- a/test/mock/usecase/entry.go
+++ b/test/mock/usecase/entry.go
@@ -57,3 +57,18 @@ func (mr *MockEntryUsecaseMockRecorder) Create(arg0, arg1, arg2, arg3, arg4, arg
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEntryUsecase)(nil).Create), arg0, arg1, arg2, arg3, arg4, arg5)
 }
+
+// Update mocks base method.
+func (m *MockEntryUsecase) Update(arg0 context.Context, arg1, arg2 uuid.UUID, arg3 string) (*dto.EntryDTO, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*dto.EntryDTO)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockEntryUsecaseMockRecorder) Update(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEntryUsecase)(nil).Update), arg0, arg1, arg2, arg3)
+}


### PR DESCRIPTION
# Issue
- close: #84

# 確認事項
- 正常時DBのレコードが変更されることを確認
- 移動先Entryが存在しない場合に作成されることを確認
- 認証失敗時に401が返却されることを確認
- 不正なリクエストボディ時に400が返却されることを確認
- 不正なID時に400が返却されることを確認
- Entryが見つからない場合に404が返却されることを確認
- Entryがすでに存在する場合に409が返却されることを確認
