### PR TITLE
【エントリー】単体取得機能を実装

### DIFF
--- a/internal/app/api/domain/repository/body.go
+++ b/internal/app/api/domain/repository/body.go
@@ -7,4 +7,5 @@ type BodyRepository interface {
 	Create(string, io.Reader) error
 	Update(string, string) error
 	Delete(string) error
+	FindOneByPath(string) (io.ReadCloser, error)
 }

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"io"
 	"path/filepath"
 
@@ -54,4 +55,8 @@ func (r *bodyRepository) Update(src, dst string) error {
 
 func (r *bodyRepository) Delete(path string) error {
 	return r.fs.RemoveAll(r.basePath + path)
+}
+
+func (r *bodyRepository) FindOneByPath(path string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
 }

--- a/internal/app/api/infrastructure/file/body.go
+++ b/internal/app/api/infrastructure/file/body.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"errors"
 	"io"
 	"path/filepath"
 
@@ -58,5 +57,14 @@ func (r *bodyRepository) Delete(path string) error {
 }
 
 func (r *bodyRepository) FindOneByPath(path string) (io.ReadCloser, error) {
-	return nil, errors.New("not implemented")
+	info, err := r.fs.Stat(r.basePath + path)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.IsDir() {
+		return nil, nil
+	}
+
+	return r.fs.Open(r.basePath + path)
 }

--- a/internal/app/api/interface/handler/entry.go
+++ b/internal/app/api/interface/handler/entry.go
@@ -25,6 +25,7 @@ type EntryHandler interface {
 	Update(*gin.Context)
 	Delete(*gin.Context)
 	Head(*gin.Context)
+	Get(*gin.Context)
 }
 
 type entryHandler struct {
@@ -148,6 +149,8 @@ func (h *entryHandler) Head(c *gin.Context) {
 
 	c.Status(http.StatusOK)
 }
+
+func (h *entryHandler) Get(c *gin.Context) {}
 
 func (h *entryHandler) openFile(fileHeader *multipart.FileHeader) (uint64, multipart.File, error) {
 	if fileHeader == nil {

--- a/internal/app/api/interface/handler/entry.go
+++ b/internal/app/api/interface/handler/entry.go
@@ -176,7 +176,12 @@ func (h *entryHandler) Get(c *gin.Context) {
 		return
 	}
 
-	defer body.Close()
+	defer func() {
+		if err := body.Close(); err != nil {
+			errors.Handle(c, err)
+			return
+		}
+	}()
 
 	c.Header("Content-Length", strconv.FormatUint(entry.Size, 10))
 	c.Header("Content-Type", entry.Type)

--- a/internal/app/api/router.go
+++ b/internal/app/api/router.go
@@ -20,4 +20,5 @@ func registerRouter(r *gin.Engine) {
 	entries.PUT("/:volumeName/*key", entryHdl.Update)
 	entries.DELETE("/:volumeName/*key", entryHdl.Delete)
 	entries.HEAD("/:volumeName/*key", entryHdl.Head)
+	entries.GET("/:volumeName/*key", entryHdl.Get)
 }

--- a/internal/app/api/usecase/entry.go
+++ b/internal/app/api/usecase/entry.go
@@ -4,7 +4,6 @@ package usecase
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"net/http"
 
@@ -198,5 +197,32 @@ func (u *entryUsecase) Head(ctx context.Context, accountID uuid.UUID, volumeName
 }
 
 func (u *entryUsecase) Get(ctx context.Context, accountID uuid.UUID, volumeName, key string) (*dto.EntryDTO, io.ReadCloser, error) {
-	return nil, nil, errors.New("not implemented")
+	var entry *entity.Entry
+	var body io.ReadCloser
+
+	if err := u.transactionObj.Transaction(ctx, func(ctx context.Context) error {
+		volume, err := u.volumeRepo.FindOneByNameAndAccountID(ctx, volumeName, accountID)
+		if err != nil {
+			return err
+		}
+		if volume == nil {
+			return ErrVolumeNotFound
+		}
+
+		entry, err = u.entryRepo.FindOneByKeyAndVolumeIDAndAccountID(ctx, key, volume.ID, accountID)
+		if err != nil {
+			return err
+		}
+		if entry == nil {
+			return ErrEntryNotFound
+		}
+
+		path := volume.Name + "/" + entry.Key
+		body, err = u.bodyRepo.FindOneByPath(path)
+		return err
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return mapper.ToEntryDTO(entry), body, nil
 }

--- a/internal/app/api/usecase/entry.go
+++ b/internal/app/api/usecase/entry.go
@@ -4,6 +4,7 @@ package usecase
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 
@@ -26,6 +27,7 @@ type EntryUsecase interface {
 	Update(context.Context, uuid.UUID, string, string, string) (*dto.EntryDTO, error)
 	Delete(context.Context, uuid.UUID, string, string) error
 	Head(context.Context, uuid.UUID, string, string) (*dto.EntryDTO, error)
+	Get(context.Context, uuid.UUID, string, string) (*dto.EntryDTO, io.ReadCloser, error)
 }
 
 type entryUsecase struct {
@@ -193,4 +195,8 @@ func (u *entryUsecase) Head(ctx context.Context, accountID uuid.UUID, volumeName
 	}
 
 	return mapper.ToEntryDTO(entry), nil
+}
+
+func (u *entryUsecase) Get(ctx context.Context, accountID uuid.UUID, volumeName, key string) (*dto.EntryDTO, io.ReadCloser, error) {
+	return nil, nil, errors.New("not implemented")
 }

--- a/test/mock/domain/repository/body.go
+++ b/test/mock/domain/repository/body.go
@@ -68,6 +68,21 @@ func (mr *MockBodyRepositoryMockRecorder) Delete(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBodyRepository)(nil).Delete), arg0)
 }
 
+// FindOneByPath mocks base method.
+func (m *MockBodyRepository) FindOneByPath(arg0 string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOneByPath", arg0)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOneByPath indicates an expected call of FindOneByPath.
+func (mr *MockBodyRepositoryMockRecorder) FindOneByPath(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByPath", reflect.TypeOf((*MockBodyRepository)(nil).FindOneByPath), arg0)
+}
+
 // Update mocks base method.
 func (m *MockBodyRepository) Update(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/test/mock/usecase/entry.go
+++ b/test/mock/usecase/entry.go
@@ -72,6 +72,22 @@ func (mr *MockEntryUsecaseMockRecorder) Delete(arg0, arg1, arg2, arg3 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEntryUsecase)(nil).Delete), arg0, arg1, arg2, arg3)
 }
 
+// Get mocks base method.
+func (m *MockEntryUsecase) Get(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (*dto.EntryDTO, io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*dto.EntryDTO)
+	ret1, _ := ret[1].(io.ReadCloser)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockEntryUsecaseMockRecorder) Get(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockEntryUsecase)(nil).Get), arg0, arg1, arg2, arg3)
+}
+
 // Head mocks base method.
 func (m *MockEntryUsecase) Head(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (*dto.EntryDTO, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Issue
- close: #86 

# 確認事項
- 正常時Entryがファイルの場合にバイナリがレスポンスされることを確認
- 正常時Entryがフォルダの場合にレスポンスボディが空であることを確認
- 認証失敗時401が返却されることを確認
- Entryが見つからない場合404が返却されることを確認
