### PR TITLE
【ボリューム】エントリーが紐づいたボリュームを削除不可にする

### DIFF
--- a/internal/app/api/domain/service/volume.go
+++ b/internal/app/api/domain/service/volume.go
@@ -3,7 +3,6 @@ package service
 
 import (
 	"context"
-	"errors"
 
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/entity"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/repository"
@@ -50,5 +49,16 @@ func (s *volumeService) Exists(ctx context.Context, volume *entity.Volume) error
 }
 
 func (s *volumeService) CanDelete(ctx context.Context, volume *entity.Volume) error {
-	return errors.New("not implemented")
+	if volume == nil {
+		return ErrRequiredVolume
+	}
+
+	entries, err := s.entryRepo.FindByVolumeIDAndAccountID(ctx, volume.ID, volume.AccountID, nil, nil)
+	if err != nil {
+		return err
+	}
+	if 0 < len(entries) {
+		return ErrVolumeHasEntries
+	}
+	return nil
 }

--- a/internal/app/api/domain/service/volume.go
+++ b/internal/app/api/domain/service/volume.go
@@ -14,6 +14,7 @@ import (
 var (
 	ErrRequiredVolume      = status.Error(code.Internal, "volume is required")
 	ErrVolumeAlreadyExists = status.Error(code.Conflict, "volume name already used")
+	ErrVolumeHasEntries    = status.Error(code.Conflict, "volume has entries")
 )
 
 type VolumeService interface {

--- a/internal/app/api/domain/service/volume.go
+++ b/internal/app/api/domain/service/volume.go
@@ -21,11 +21,13 @@ type VolumeService interface {
 
 type volumeService struct {
 	volumeRepo repository.VolumeRepository
+	entryRepo  repository.EntryRepository
 }
 
-func NewVolumeService(volumeRepo repository.VolumeRepository) VolumeService {
+func NewVolumeService(volumeRepo repository.VolumeRepository, entryRepo repository.EntryRepository) VolumeService {
 	return &volumeService{
 		volumeRepo: volumeRepo,
+		entryRepo:  entryRepo,
 	}
 }
 

--- a/internal/app/api/domain/service/volume.go
+++ b/internal/app/api/domain/service/volume.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/entity"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/repository"
@@ -17,6 +18,7 @@ var (
 
 type VolumeService interface {
 	Exists(context.Context, *entity.Volume) error
+	CanDelete(context.Context, *entity.Volume) error
 }
 
 type volumeService struct {
@@ -44,4 +46,8 @@ func (s *volumeService) Exists(ctx context.Context, volume *entity.Volume) error
 		return nil
 	}
 	return ErrVolumeAlreadyExists
+}
+
+func (s *volumeService) CanDelete(ctx context.Context, volume *entity.Volume) error {
+	return errors.New("not implemented")
 }

--- a/internal/app/api/domain/service/volume_test.go
+++ b/internal/app/api/domain/service/volume_test.go
@@ -84,7 +84,7 @@ func TestVolume_Exists(t *testing.T) {
 			volumeRepo := mockRepository.NewMockVolumeRepository(ctrl)
 			tt.setMockVolumeRepo(ctx, volumeRepo)
 
-			serv := service.NewVolumeService(volumeRepo)
+			serv := service.NewVolumeService(volumeRepo, nil)
 			if err := serv.Exists(ctx, tt.inputVolume); !errors.Is(err, tt.expectError) {
 				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
 			}

--- a/internal/app/api/domain/service/volume_test.go
+++ b/internal/app/api/domain/service/volume_test.go
@@ -91,3 +91,90 @@ func TestVolume_Exists(t *testing.T) {
 		})
 	}
 }
+
+func TestVolume_CanDelete(t *testing.T) {
+	volume := &entity.Volume{
+		ID:        uuid.New(),
+		AccountID: uuid.New(),
+		Name:      "name",
+		IsPublic:  false,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	entry := &entity.Entry{
+		ID:        uuid.New(),
+		AccountID: volume.ID,
+		VolumeID:  volume.AccountID,
+		Key:       "test/sample.txt",
+		Size:      10000,
+		Type:      "text/plain",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	tests := []struct {
+		name             string
+		inputVolume      *entity.Volume
+		expectError      error
+		setMockEntryRepo func(context.Context, *mockRepository.MockEntryRepository)
+	}{
+		{
+			name:        "volume has not entries",
+			inputVolume: volume,
+			expectError: nil,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByVolumeIDAndAccountID(ctx, volume.ID, volume.AccountID, gomock.Any(), gomock.Any()).
+					Return(nil, nil).
+					Times(1)
+			},
+		},
+		{
+			name:        "volume has entries",
+			inputVolume: volume,
+			expectError: service.ErrVolumeHasEntries,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByVolumeIDAndAccountID(ctx, volume.ID, volume.AccountID, gomock.Any(), gomock.Any()).
+					Return([]*entity.Entry{entry}, nil).
+					Times(1)
+			},
+		},
+		{
+			name:             "volume is nil",
+			inputVolume:      nil,
+			expectError:      service.ErrRequiredVolume,
+			setMockEntryRepo: func(context.Context, *mockRepository.MockEntryRepository) {},
+		},
+		{
+			name:        "find error",
+			inputVolume: volume,
+			expectError: sql.ErrConnDone,
+			setMockEntryRepo: func(ctx context.Context, entryRepo *mockRepository.MockEntryRepository) {
+				entryRepo.
+					EXPECT().
+					FindByVolumeIDAndAccountID(ctx, volume.ID, volume.AccountID, gomock.Any(), gomock.Any()).
+					Return(nil, sql.ErrConnDone).
+					Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := t.Context()
+
+			entryRepo := mockRepository.NewMockEntryRepository(ctrl)
+			tt.setMockEntryRepo(ctx, entryRepo)
+
+			serv := service.NewVolumeService(nil, entryRepo)
+			if err := serv.CanDelete(ctx, tt.inputVolume); !errors.Is(err, tt.expectError) {
+				t.Errorf("\nexpect: %v\ngot: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/internal/app/api/injection.go
+++ b/internal/app/api/injection.go
@@ -32,7 +32,7 @@ func inject(db *sqlx.DB, fs afero.Fs, config *serverConfig) {
 	entryRepo := database.NewEntryRepository(db)
 	bodyRepo := file.NewBodyRepository(fs, config.fileSystem.BasePath)
 
-	volumeServ := service.NewVolumeService(volumeRepo)
+	volumeServ := service.NewVolumeService(volumeRepo, entryRepo)
 	entryServ := service.NewEntryService(entryRepo)
 
 	authorizationUC := usecase.NewAuthorizationUsecase(accountRepo)

--- a/internal/app/api/usecase/volume.go
+++ b/internal/app/api/usecase/volume.go
@@ -116,6 +116,10 @@ func (u *volumeUsecase) Delete(ctx context.Context, accountID, id uuid.UUID) err
 			return ErrVolumeNotFound
 		}
 
+		if err := u.volumeServ.CanDelete(ctx, volume); err != nil {
+			return err
+		}
+
 		if err := u.volumeRepo.Delete(ctx, volume); err != nil {
 			return err
 		}

--- a/test/mock/domain/service/volume.go
+++ b/test/mock/domain/service/volume.go
@@ -41,6 +41,20 @@ func (m *MockVolumeService) EXPECT() *MockVolumeServiceMockRecorder {
 	return m.recorder
 }
 
+// CanDelete mocks base method.
+func (m *MockVolumeService) CanDelete(arg0 context.Context, arg1 *entity.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanDelete", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CanDelete indicates an expected call of CanDelete.
+func (mr *MockVolumeServiceMockRecorder) CanDelete(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanDelete", reflect.TypeOf((*MockVolumeService)(nil).CanDelete), arg0, arg1)
+}
+
 // Exists mocks base method.
 func (m *MockVolumeService) Exists(arg0 context.Context, arg1 *entity.Volume) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Issue
- close: #114 

# 確認事項
- ボリュームにエントリーが紐づいている場合409が返却されることを確認
- ボリュームにエントリーが紐づいていない場合ボリュームが削除されることを確認