### PR TITLE
【エントリー】情報取得並びに単体取得時の認可を変更

### DIFF
--- a/internal/app/api/domain/entity/account.go
+++ b/internal/app/api/domain/entity/account.go
@@ -6,6 +6,12 @@ type Account struct {
 	ID uuid.UUID
 }
 
+func NewAccount(id uuid.UUID) *Account {
+	return &Account{
+		ID: id,
+	}
+}
+
 func RestoreAccount(id uuid.UUID) *Account {
 	return &Account{
 		ID: id,

--- a/internal/app/api/domain/repository/account.go
+++ b/internal/app/api/domain/repository/account.go
@@ -5,7 +5,11 @@ import (
 	"context"
 
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/entity"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status/code"
 )
+
+var ErrUnauthorized = status.Error(code.Unauthorized, "unauthorized")
 
 type AccountRepository interface {
 	FindOneByCredential(context.Context, string) (*entity.Account, error)

--- a/internal/app/api/infrastructure/api/account.go
+++ b/internal/app/api/infrastructure/api/account.go
@@ -42,7 +42,9 @@ func (r *accountRepository) FindOneByCredential(ctx context.Context, credential 
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, repository.ErrUnauthorized
+	} else if resp.StatusCode != http.StatusOK {
 		return nil, errors.Decode(resp)
 	}
 

--- a/internal/app/api/injection.go
+++ b/internal/app/api/injection.go
@@ -35,7 +35,7 @@ func inject(db *sqlx.DB, fs afero.Fs, config *serverConfig) {
 	volumeServ := service.NewVolumeService(volumeRepo, entryRepo)
 	entryServ := service.NewEntryService(entryRepo)
 
-	authorizationUC := usecase.NewAuthorizationUsecase(accountRepo)
+	authorizationUC := usecase.NewAuthorizationUsecase(accountRepo, volumeRepo)
 	volumeUC := usecase.NewVolumeUsecase(transactionObj, volumeRepo, bodyRepo, volumeServ)
 	entryUC := usecase.NewEntryUsecase(transactionObj, entryRepo, bodyRepo, volumeRepo, entryServ)
 

--- a/internal/app/api/interface/middleware/authorization.go
+++ b/internal/app/api/interface/middleware/authorization.go
@@ -1,13 +1,9 @@
 package middleware
 
 import (
-	"strings"
-
 	"github.com/gin-gonic/gin"
 
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/interface/pkg/errors"
-	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status"
-	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status/code"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/usecase"
 )
 
@@ -27,16 +23,13 @@ func NewAuthorizationMiddleware(authorizationUC usecase.AuthorizationUsecase) Au
 
 func (m *authorizationMiddleware) Authorize(c *gin.Context) {
 	credential := c.Request.Header.Get("Authorization")
-	if len(strings.Split(credential, " ")) != 2 {
-		err := status.Error(code.Unauthorized, "unauthorized")
-		errors.Handle(c, err)
-		c.Abort()
-		return
-	}
+	volumeName := c.Param("volumeName")
+	key := c.Param("key")
+	method := c.Request.Method
 
 	ctx := c.Request.Context()
 
-	account, err := m.authorizationUC.Authorize(ctx, credential)
+	account, err := m.authorizationUC.Authorize(ctx, credential, volumeName, key, method)
 	if err != nil {
 		errors.Handle(c, err)
 		c.Abort()

--- a/internal/app/api/interface/middleware/authorization_test.go
+++ b/internal/app/api/interface/middleware/authorization_test.go
@@ -35,16 +35,10 @@ func TestAuthorization_Authorize(t *testing.T) {
 			expectResult:        accountDTO.ID,
 			setMockAuthorizationUC: func(ctx context.Context, authorizationUC *mockUsecase.MockAuthorizationUsecase) {
 				authorizationUC.EXPECT().
-					Authorize(ctx, gomock.Any()).
+					Authorize(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(accountDTO, nil).
 					Times(1)
 			},
-		},
-		{
-			name:                   "invalid authorization header",
-			authorizationHeader:    "",
-			expectResult:           uuid.Nil,
-			setMockAuthorizationUC: func(context.Context, *mockUsecase.MockAuthorizationUsecase) {},
 		},
 		{
 			name:                "authorize error",
@@ -52,7 +46,7 @@ func TestAuthorization_Authorize(t *testing.T) {
 			expectResult:        uuid.Nil,
 			setMockAuthorizationUC: func(ctx context.Context, authorizationUC *mockUsecase.MockAuthorizationUsecase) {
 				authorizationUC.EXPECT().
-					Authorize(ctx, gomock.Any()).
+					Authorize(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, http.ErrServerClosed).
 					Times(1)
 			},

--- a/internal/app/api/usecase/authorization.go
+++ b/internal/app/api/usecase/authorization.go
@@ -3,29 +3,53 @@ package usecase
 
 import (
 	"context"
+	"errors"
 
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/entity"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/domain/repository"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status"
+	"github.com/atsumarukun/holos-storage-api/internal/app/api/pkg/status/code"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/usecase/dto"
 	"github.com/atsumarukun/holos-storage-api/internal/app/api/usecase/mapper"
 )
 
+var ErrForbidden = status.Error(code.Forbidden, "forbidden")
+
 type AuthorizationUsecase interface {
-	Authorize(context.Context, string) (*dto.AccountDTO, error)
+	Authorize(context.Context, string, string, string, string) (*dto.AccountDTO, error)
 }
 
 type authorizationUsecase struct {
 	accountRepo repository.AccountRepository
+	volumeRepo  repository.VolumeRepository
 }
 
-func NewAuthorizationUsecase(accountRepo repository.AccountRepository) AuthorizationUsecase {
+func NewAuthorizationUsecase(accountRepo repository.AccountRepository, volumeRepo repository.VolumeRepository) AuthorizationUsecase {
 	return &authorizationUsecase{
 		accountRepo: accountRepo,
+		volumeRepo:  volumeRepo,
 	}
 }
 
-func (u *authorizationUsecase) Authorize(ctx context.Context, credential string) (*dto.AccountDTO, error) {
+func (u *authorizationUsecase) Authorize(ctx context.Context, credential, volumeName, key, method string) (*dto.AccountDTO, error) {
+	isGetEntry := volumeName != "" && key != "" && (method == "GET" || method == "HEAD")
+
+	if isGetEntry {
+		volume, err := u.volumeRepo.FindOneByName(ctx, volumeName)
+		if err != nil {
+			return nil, err
+		}
+		if volume.IsPublic {
+			account := entity.NewAccount(volume.AccountID)
+			return mapper.ToAccountDTO(account), nil
+		}
+	}
+
 	account, err := u.accountRepo.FindOneByCredential(ctx, credential)
 	if err != nil {
+		if isGetEntry && credential == "" && errors.Is(err, repository.ErrUnauthorized) {
+			return nil, ErrForbidden
+		}
 		return nil, err
 	}
 

--- a/test/mock/usecase/authorization.go
+++ b/test/mock/usecase/authorization.go
@@ -42,16 +42,16 @@ func (m *MockAuthorizationUsecase) EXPECT() *MockAuthorizationUsecaseMockRecorde
 }
 
 // Authorize mocks base method.
-func (m *MockAuthorizationUsecase) Authorize(arg0 context.Context, arg1 string) (*dto.AccountDTO, error) {
+func (m *MockAuthorizationUsecase) Authorize(arg0 context.Context, arg1, arg2, arg3, arg4 string) (*dto.AccountDTO, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Authorize", arg0, arg1)
+	ret := m.ctrl.Call(m, "Authorize", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*dto.AccountDTO)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Authorize indicates an expected call of Authorize.
-func (mr *MockAuthorizationUsecaseMockRecorder) Authorize(arg0, arg1 any) *gomock.Call {
+func (mr *MockAuthorizationUsecaseMockRecorder) Authorize(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockAuthorizationUsecase)(nil).Authorize), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authorize", reflect.TypeOf((*MockAuthorizationUsecase)(nil).Authorize), arg0, arg1, arg2, arg3, arg4)
 }


### PR DESCRIPTION
# Issue
- close: #134 

# 確認事項
- isPublicがtrueのときに認可なしでEntry情報取得が行えることを確認
- isPublicがtrueのときに認可なしでEntry単体取得が行えることを確認
- isPublicがfalseのときに認証情報なしでEntry情報取得を行った際に403が返却されることを確認
- isPublicがfalseのときに認証情報なしでEntry単体取得を行った際に403が返却されることを確認
- isPublicがfalseのときに不正な認証情報でEntry情報取得を行った際に401が返却されることを確認
- isPublicがfalseのときに不正な認証情報でEntry単体取得を行った際に401が返却されることを確認
- isPublicがfalseのとき認証成功した場合にEntry情報取得が行えることを確認
- isPublicがfalseのとき認証成功した場合にEntry単体取得が行えることを確認