### PR TITLE
【ボリューム】公開状況のみ更新時にボリューム名重複でエラーになる問題の対応 

### DIFF
--- a/internal/app/api/usecase/volume.go
+++ b/internal/app/api/usecase/volume.go
@@ -77,20 +77,21 @@ func (u *volumeUsecase) Update(ctx context.Context, accountID uuid.UUID, name, n
 		}
 
 		volume.SetIsPublic(isPublic)
-
-		if volume.Name != newName {
-			if err := volume.SetName(newName); err != nil {
-				return err
-			}
-			if err := u.volumeServ.Exists(ctx, volume); err != nil {
-				return err
-			}
-			if err := u.bodyRepo.Update(name, volume.Name); err != nil {
-				return err
-			}
+		if volume.Name == newName {
+			return u.volumeRepo.Update(ctx, volume)
 		}
 
-		return u.volumeRepo.Update(ctx, volume)
+		if err := volume.SetName(newName); err != nil {
+			return err
+		}
+		if err := u.volumeServ.Exists(ctx, volume); err != nil {
+			return err
+		}
+		if err := u.volumeRepo.Update(ctx, volume); err != nil {
+			return err
+		}
+
+		return u.bodyRepo.Update(name, volume.Name)
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/app/api/usecase/volume.go
+++ b/internal/app/api/usecase/volume.go
@@ -76,20 +76,21 @@ func (u *volumeUsecase) Update(ctx context.Context, accountID uuid.UUID, name, n
 			return err
 		}
 
-		if err := volume.SetName(newName); err != nil {
-			return err
-		}
 		volume.SetIsPublic(isPublic)
 
-		if err := u.volumeServ.Exists(ctx, volume); err != nil {
-			return err
+		if volume.Name != newName {
+			if err := volume.SetName(newName); err != nil {
+				return err
+			}
+			if err := u.volumeServ.Exists(ctx, volume); err != nil {
+				return err
+			}
+			if err := u.bodyRepo.Update(name, volume.Name); err != nil {
+				return err
+			}
 		}
 
-		if err := u.volumeRepo.Update(ctx, volume); err != nil {
-			return err
-		}
-
-		return u.bodyRepo.Update(name, volume.Name)
+		return u.volumeRepo.Update(ctx, volume)
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/app/api/usecase/volume_test.go
+++ b/internal/app/api/usecase/volume_test.go
@@ -238,10 +238,18 @@ func TestVolume_Update(t *testing.T) {
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
-	volumeDTO := &dto.VolumeDTO{
+	updatedNameVolumeDTO := &dto.VolumeDTO{
 		ID:        volume.ID,
 		AccountID: volume.AccountID,
 		Name:      "update",
+		IsPublic:  volume.IsPublic,
+		CreatedAt: volume.CreatedAt,
+		UpdatedAt: volume.UpdatedAt,
+	}
+	unupdatedNameVolumeDTO := &dto.VolumeDTO{
+		ID:        volume.ID,
+		AccountID: volume.AccountID,
+		Name:      volume.Name,
 		IsPublic:  volume.IsPublic,
 		CreatedAt: volume.CreatedAt,
 		UpdatedAt: volume.UpdatedAt,
@@ -271,7 +279,7 @@ func TestVolume_Update(t *testing.T) {
 			inputName:      "name",
 			inputNewName:   "update",
 			inputIsPublic:  false,
-			expectResult:   volumeDTO,
+			expectResult:   updatedNameVolumeDTO,
 			expectError:    nil,
 			setMockTransactionObj: func(transactionObj *mockTransaction.MockTransactionObject) {
 				transactionObj.
@@ -308,6 +316,38 @@ func TestVolume_Update(t *testing.T) {
 					Return(nil).
 					Times(1)
 			},
+		},
+		{
+			name:           "not updated volume name",
+			inputAccountID: accountID,
+			inputName:      "name",
+			inputNewName:   "name",
+			inputIsPublic:  false,
+			expectResult:   unupdatedNameVolumeDTO,
+			expectError:    nil,
+			setMockTransactionObj: func(transactionObj *mockTransaction.MockTransactionObject) {
+				transactionObj.
+					EXPECT().
+					Transaction(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, fn func(context.Context) error) error {
+						return fn(ctx)
+					}).
+					Times(1)
+			},
+			setMockVolumeRepo: func(volumeRepo *mockRepository.MockVolumeRepository) {
+				volumeRepo.
+					EXPECT().
+					FindOneByNameAndAccountID(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(volume, nil).
+					Times(1)
+				volumeRepo.
+					EXPECT().
+					Update(gomock.Any(), gomock.Any()).
+					Return(nil).
+					Times(1)
+			},
+			setMockBodyRepo:   func(*mockRepository.MockBodyRepository) {},
+			setMockVolumeServ: func(*mockService.MockVolumeService) {},
 		},
 		{
 			name:           "invalid name",


### PR DESCRIPTION
# Issue
- close: #154 

# 確認事項
- 公開情報のみ更新時にエラーにならないことを確認
